### PR TITLE
Nested div bug

### DIFF
--- a/css/jquery.accordion.css
+++ b/css/jquery.accordion.css
@@ -149,7 +149,7 @@
   position:relative;
   display:block;
   float:left;
-  overflow: hidden;
+  overflow-x: hidden;
   *top:0px;       /* IE7 Hack */
   *left:0px;      /* IE7 Hack */
   margin:0;

--- a/jquery.accordion.js
+++ b/jquery.accordion.js
@@ -394,7 +394,7 @@
               $(headLis).parent().find('li').eq(i).css({
                 'width': settings.cssAttrsHor.liWidth + 'px',
                 'height': settings.cssAttrsHor.liHeight + 'px'
-              }).find('div').css({
+              }).find('div:first').css({
                 'left': settings.cssAttrsHor.liWidth + 'px',
                 'width': methods.calcDivWidthHor() + 'px',
                 'height': settings.cssAttrsHor.liHeight + 'px'


### PR DESCRIPTION
Nested divs inside an accordion panel all get the height, width, and left CSS properties applied to them causing layout issues.

I also changed the overflow CSS property for horizontal accordions to hide only for the 'x'.
